### PR TITLE
Add monkeylaunch

### DIFF
--- a/config/testconfig.txt
+++ b/config/testconfig.txt
@@ -1,0 +1,3 @@
+demo_pub
+other_topic
+third_topic

--- a/config/testconfig.txt
+++ b/config/testconfig.txt
@@ -1,3 +1,3 @@
-demo_pub
-other_topic
-third_topic
+source:demo_pub
+other_source:other_topic
+wonk:third_topic

--- a/launch/testlaunch.launch
+++ b/launch/testlaunch.launch
@@ -11,4 +11,18 @@
         <param name="publish_hz" value="15"/>
         <param name="subscribe_topic" value="demo_pub"/>
     </node>
+
+    <node name='other_source' pkg='monkeywrench' type='dummynode' output='screen'>
+        <param name="topic_type" value="std_msgs/Float32"/>
+        <param name="publish_topic" value="other_topic"/>
+        <param name="publish_hz" value="15"/>
+        <param name="subscribe_topic" value=""/>
+    </node>
+    <node name='other_topic' pkg='monkeywrench' type='dummynode' output='screen'>
+        <param name="topic_type" value="std_msgs/Float32"/>
+        <param name="publish_topic" value=""/>
+        <param name="publish_hz" value="15"/>
+        <param name="subscribe_topic" value="other_topic"/>
+    </node>
+
 </launch>

--- a/src/monkeylaunch
+++ b/src/monkeylaunch
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import roslaunch
+import sys
+import os
+from roslaunch import config
+from roslaunch.core import Node
+import rospkg
+import yaml
+
+original_load_config = config.load_config_default
+
+config_file = sys.argv[-1]
+
+def construct_remappings(subs, pubs, topics_of_interest):
+    remapping_in = []
+    remapping_out = []
+    for t in topics_of_interest:
+        if t in subs:
+            remapping_in.append([t, "{}_mwin".format(t)])
+        if t in pubs:
+            remapping_out.append(["{}_mwout".format(t), t])
+    return remapping_in, remapping_out
+
+
+def get_node_file(node: Node):
+    package_path = rospkg.RosPack().get_path(node.package)
+    file_name = node.type
+    for (root, _, files) in os.walk(package_path):
+        if file_name in files:
+            return os.path.join(root, file_name)
+    return ''
+
+def new_load_config(
+    roslaunch_files,
+    port,
+    roslaunch_strs=None,
+    loader=None,
+    verbose=False,
+    assign_machines=True,
+    ignore_unset_args=False,
+):
+    config = original_load_config(
+        roslaunch_files,
+        port,
+        roslaunch_strs,
+        loader,
+        verbose,
+        assign_machines,
+        ignore_unset_args,
+    )
+
+    for n in config.nodes:
+        n.remap_args += construct_remappings(subs, pubs, topics_of_interest)
+    return config
+
+
+config.load_config_default = new_load_config
+roslaunch.main(sys.argv[:-1])

--- a/src/monkeylaunch
+++ b/src/monkeylaunch
@@ -1,35 +1,42 @@
 #!/usr/bin/env python3
 
+from copy import deepcopy
 import roslaunch
 import sys
 import os
 from roslaunch import config
 from roslaunch.core import Node
 import rospkg
-import yaml
+from typing import List
 
 original_load_config = config.load_config_default
 
 config_file = sys.argv[-1]
 
-def construct_remappings(subs, pubs, topics_of_interest):
-    remapping_in = []
-    remapping_out = []
-    for t in topics_of_interest:
-        if t in subs:
-            remapping_in.append([t, "{}_mwin".format(t)])
-        if t in pubs:
-            remapping_out.append(["{}_mwout".format(t), t])
-    return remapping_in, remapping_out
+
+def construct_remappings(n, source_nodes: List, source_topics: List):
+    remappings = []
+    new_node = None
+    for t in source_topics:
+        if n.name == source_nodes[source_topics.index(t)]:
+            index = source_nodes.index(n.name)
+            remappings.append(
+                [source_topics[index], "{}_mwin".format(source_topics[index])]
+            )
+            new_node = construct_monkeynode(t, n)
+        else:
+            remappings.append([t, "{}_mwout".format(t)])
+    return n.remap_args + remappings, new_node
 
 
-def get_node_file(node: Node):
-    package_path = rospkg.RosPack().get_path(node.package)
-    file_name = node.type
-    for (root, _, files) in os.walk(package_path):
-        if file_name in files:
-            return os.path.join(root, file_name)
-    return ''
+def construct_monkeynode(t, source_node: Node):
+    n = deepcopy(source_node)
+    n.name = n.name + "_mw" if n.name is not None else "_mw"
+    n.package = "monkeywrench"
+    n.type = "monkeywrench"
+    n.remap_args += [["sub", "{}_mwin".format(t)], ["pub", "{}_mwout".format(t)]]
+    return n
+
 
 def new_load_config(
     roslaunch_files,
@@ -50,8 +57,21 @@ def new_load_config(
         ignore_unset_args,
     )
 
+    source_topics = []
+    source_nodes = []
+    with open(config_file, "r") as t:
+        for line in t.readlines():
+            stripchars = " \t\r\n\"'"
+            node_topic_pair = line.split(":")
+            source_nodes.append(node_topic_pair[0].strip(stripchars))
+            source_topics.append(node_topic_pair[1].strip(stripchars))
+
+    new_nodes = []
     for n in config.nodes:
-        n.remap_args += construct_remappings(subs, pubs, topics_of_interest)
+        n.remap_args, new_node = construct_remappings(n, source_nodes, source_topics)
+        if new_node is not None:
+            new_nodes.append(new_node)
+    config.nodes += new_nodes
     return config
 
 

--- a/src/monkeywrench
+++ b/src/monkeywrench
@@ -167,7 +167,7 @@ class MonkeyWrench:
         self.changetime = changetime
 
         self.constant = srv.constant
-        self.noise_std_dev = srv.noise_std_dev if srv.noise_std_dev is not 0 else 1
+        self.noise_std_dev = srv.noise_std_dev if srv.noise_std_dev != 0 else 1
         self.time_change = srv.time_change
 
         self.subtopics = srv.apply_to_subtopics


### PR DESCRIPTION
drop-in replacement for `roslaunch` command that also takes in a config file. That config file points out what topics from what nodes to introspect on, and creates a new node which slips in between sources and sinks. This all occurs introspectively.